### PR TITLE
Fixes report posting to sub-uri deployemnts of Foreman

### DIFF
--- a/lib/smart_proxy_abrt/abrt_lib.rb
+++ b/lib/smart_proxy_abrt/abrt_lib.rb
@@ -104,7 +104,7 @@ module AbrtProxy
 
   class AbrtRequest < Proxy::HttpRequest::ForemanRequest
     def post_report(report)
-      send_request(request_factory.create_post('/api/abrt_reports', report))
+      send_request(request_factory.create_post('api/abrt_reports', report))
     end
   end
 


### PR DESCRIPTION
When posting report to Foreman, you use absolute url which does not work on sub-uri deployments (e.g. https://example.com/foreman). This will PR fixes it.