### PR TITLE
Allow insecure mode for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/lib/smart_proxy_abrt/abrt_plugin.rb
+++ b/lib/smart_proxy_abrt/abrt_plugin.rb
@@ -4,6 +4,7 @@ module AbrtProxy
   class Plugin < ::Proxy::Plugin
     plugin :abrt, AbrtProxy::VERSION
 
+    http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     default_settings :spooldir => "/var/spool/foreman-proxy-abrt",

--- a/settings.d/abrt.yml.example
+++ b/settings.d/abrt.yml.example
@@ -24,3 +24,5 @@
 #:server_ssl_cert: /etc/foreman-proxy/faf_client_cert.pem
 #:server_ssl_key: /etc/foreman-proxy/faf_cleint_key.pem
 
+# Ignore SSL (for development only)
+#:insecure: true


### PR DESCRIPTION
I dont use Puppet therefore its tricky to setup HTTPS. This patch adds insecure
option that bypasses the cert checks.